### PR TITLE
Clone clipping

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,8 +6,8 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/cmake-mod
 set(Boost_USE_STATIC_LIBS ON)
 set(CMAKE_CXX_STANDARD 14)
 set(FLTK_SKIP_FLUID true)
-# set(CMAKE_BUILD_TYPE Debug)
-set(CMAKE_BUILD_TYPE Release)
+set(CMAKE_BUILD_TYPE Debug)
+# set(CMAKE_BUILD_TYPE Release)
 
 find_path(AVCODEC_INCLUDE_DIR libavcodec/avcodec.h)
 find_library(AVCODEC_LIBRARY avcodec)

--- a/src/clippings/clipping_conversion.cpp
+++ b/src/clippings/clipping_conversion.cpp
@@ -7,6 +7,7 @@
 #include <Fl/Fl.H>
 #include "src/clippings/clipping_iterator.h"
 #include "src/clippings/clipping_conversion.h"
+#include "src/wnd_common/common_dialogs.h"
 #include "src/common/utils.h"
 
 namespace vcutter {
@@ -56,6 +57,7 @@ bool ClippingConversion::convert(
     auto encoder = vs::encoder(codec, path, clipping_->w(), clipping_->h(), 1000, fps * 1000, bitrate);
 
     if (encoder->error()) {
+        show_error(encoder->error());
         return false;
     }
 

--- a/src/clippings/clipping_conversion.cpp
+++ b/src/clippings/clipping_conversion.cpp
@@ -14,7 +14,7 @@ namespace vcutter {
 
 ClippingConversion::ClippingConversion(
     std::shared_ptr<ProgressHandler> prog_handler,
-    std::shared_ptr<Clipping> clipping,
+    std::shared_ptr<ClippingRender> clipping,
     uint32_t max_memory
 ) {
     max_memory_ = max_memory;

--- a/src/clippings/clipping_conversion.h
+++ b/src/clippings/clipping_conversion.h
@@ -29,7 +29,7 @@ class ProgressHandler {
 
 class ClippingConversion: private boost::noncopyable {
  public:
-    ClippingConversion(std::shared_ptr<ProgressHandler> prog_handler, std::shared_ptr<Clipping> clipping, uint32_t max_memory=419430400);
+    ClippingConversion(std::shared_ptr<ProgressHandler> prog_handler, std::shared_ptr<ClippingRender> clipping, uint32_t max_memory=419430400);
 
     bool convert(
         const char *codec,
@@ -50,7 +50,7 @@ class ClippingConversion: private boost::noncopyable {
     std::atomic<uint32_t> current_position_;
     std::atomic<uint8_t*> last_encoded_buffer_;
     uint32_t max_position_;
-    std::shared_ptr<Clipping> clipping_;
+    std::shared_ptr<ClippingRender> clipping_;
     std::shared_ptr<ProgressHandler> prog_handler_;
     std::list<std::shared_ptr<CharBuffer> > transitions_;
     float current_alpha_;

--- a/src/clippings/clipping_iterator.cpp
+++ b/src/clippings/clipping_iterator.cpp
@@ -6,7 +6,7 @@
 
 namespace vcutter {
 
-ClippingIterator::ClippingIterator(Clipping *clipping, uint32_t max_memory) {
+ClippingIterator::ClippingIterator(ClippingRender *clipping, uint32_t max_memory) {
     max_memory_ = max_memory;
     clipping_ = clipping;
     render_buffer_.reset(new CharBuffer(clipping_->req_buffer_size()));

--- a/src/clippings/clipping_iterator.h
+++ b/src/clippings/clipping_iterator.h
@@ -17,7 +17,7 @@ typedef std::function<bool(uint8_t *output_buffer)> frame_iteration_cb_t;
 
 class ClippingIterator {
  public:
-    ClippingIterator(Clipping *clipping, uint32_t max_memory);
+    ClippingIterator(ClippingRender *clipping, uint32_t max_memory);
     virtual ~ClippingIterator() {}
     void iterate(bool from_start, bool append_reverse, frame_iteration_cb_t cb);
     bool finished();
@@ -31,7 +31,7 @@ class ClippingIterator {
     bool flush_buffers(frame_iteration_cb_t cb);
 
  private:
-    Clipping *clipping_;
+    ClippingRender *clipping_;
     std::unique_ptr<FifoBuffer> buffers_;
     std::unique_ptr<CharBuffer> render_buffer_;
     std::list<std::shared_ptr<CharBuffer> > frames_;

--- a/src/clippings/clipping_render.cpp
+++ b/src/clippings/clipping_render.cpp
@@ -138,4 +138,15 @@ void ClippingRender::render(ClippingKey key, uint8_t *buffer) {
         buffer);
 }
 
+std::shared_ptr<ClippingRender> ClippingRender::clone() {
+  std::shared_ptr<ClippingRender> clipping(new ClippingRender(video_path().c_str(), true));
+  clipping->wh(w(), h());
+
+  for (const auto & k : keys()) {
+    clipping->add(k);
+  }
+
+  return clipping;
+}
+
 }  // namespace vcutter

--- a/src/clippings/clipping_render.h
+++ b/src/clippings/clipping_render.h
@@ -6,6 +6,7 @@
 #define SRC_CLIPPINGS_CLIPPING_RENDER_H_
 
 #include <inttypes.h>
+#include <memory>
 
 #include "src/wrappers/video_player.h"
 #include "src/clippings/clipping_frame.h"
@@ -20,6 +21,7 @@ class ClippingRender: public ClippingFrame {
     void render(ClippingKey key, uint32_t target_w, uint32_t target_h, uint8_t *buffer);
     void render(ClippingKey key, uint8_t *buffer);
     void render(ClippingKey key, uint8_t *player_buffer, uint8_t *buffer);
+    std::shared_ptr<ClippingRender> clone();
  private:
     void render(ClippingKey key, uint8_t *source_buffer, uint32_t target_w, uint32_t target_h, uint8_t *buffer);
 };

--- a/src/data/json_file.cpp
+++ b/src/data/json_file.cpp
@@ -59,6 +59,7 @@ bool JsonFile::save() {
     if (ofile.is_open()) {
         Json::FastWriter writer;
         ofile << writer.write(root_);
+        loaded_ = true;
         return true;
     }
 

--- a/src/wnd_cutter/cutter_window.cpp
+++ b/src/wnd_cutter/cutter_window.cpp
@@ -412,8 +412,8 @@ void CutterWindow::open_video() {
 
 }
 
-std::shared_ptr<Clipping> CutterWindow::to_clipping() {
-    return clipping_;
+std::shared_ptr<ClippingRender> CutterWindow::to_clipping() {
+    return clipping_->clone();
 }
 
 void CutterWindow::button_callback(Fl_Widget* widget, void *userdata) {

--- a/src/wnd_cutter/cutter_window.h
+++ b/src/wnd_cutter/cutter_window.h
@@ -43,7 +43,7 @@ class CutterWindow {
     bool save_as(History * history);
 
     void close();
-    std::shared_ptr<Clipping> to_clipping();
+    std::shared_ptr<ClippingRender> to_clipping();
     void poll_actions();
     bool visible();
     bool modified();

--- a/src/wnd_cutter/options_window.cpp
+++ b/src/wnd_cutter/options_window.cpp
@@ -145,6 +145,9 @@ void CutterOptionsWindow::sync_wh(const void *who) {
     if (who == edt_width_) {
         copy_number(edt_width_->value(), &v);
         v = (v / scale) + 0.5;
+        if (v % 2 != 0) {
+            v += 1;
+        }
         snprintf(buffer, sizeof(buffer) - 1, "%d", v);
         edt_height_->value(buffer);
     } else {
@@ -175,6 +178,8 @@ bool CutterOptionsWindow::validate_inputs(bool show_errors) {
         error = "The width must be multiple of 2";
     } else if (!copy_number(edt_height_->value(), &h)) {
         error = "You must type a valid width";
+    } else if (h % 2) {
+        error = "The height must be multiple of 2";
     } else if (w > max_w_) {
         snprintf(buffer, sizeof(buffer), "The max allowed with is %u", max_w_);
         error = buffer;

--- a/src/wnd_tools/encoder_window.cpp
+++ b/src/wnd_tools/encoder_window.cpp
@@ -50,7 +50,7 @@ bool should_replace(const char *path) {
     return true;
 }
 
-EncoderWindow::EncoderWindow(History *history, std::shared_ptr<Clipping> clip) {
+EncoderWindow::EncoderWindow(History *history, std::shared_ptr<ClippingRender> clip) {
     init(history, clip);
 }
 
@@ -64,7 +64,7 @@ EncoderWindow::EncoderWindow(History* history, const std::string& path) {
 }
 
 
-void EncoderWindow::init(History* history, std::shared_ptr<Clipping> clip) {
+void EncoderWindow::init(History* history, std::shared_ptr<ClippingRender> clip) {
     history_ = history;
     clip_ = clip;
 
@@ -292,7 +292,7 @@ bool EncoderWindow::deserialize(const string_map_t & data) {
             return false;
         }
 
-        clip_.reset(new Clipping(&clipping_data));
+        clip_.reset(new ClippingRender(&clipping_data));
 
         if (!clip_->good()) {
             clip_.reset();
@@ -305,7 +305,7 @@ bool EncoderWindow::deserialize(const string_map_t & data) {
     return true;
 }
 
-void EncoderWindow::execute(History* history, Fl_Window *parent, std::shared_ptr<Clipping> clip) {
+void EncoderWindow::execute(History* history, Fl_Window *parent, std::shared_ptr<ClippingRender> clip) {
     if (clip->video_path().empty()) {
         show_error("The clip must define a path to de video");
         return;
@@ -504,10 +504,10 @@ void EncoderWindow::action_convert() {
     session.save();
 
     std::shared_ptr<ProgressHandler> prog(new ProgressWindow(true));
-    std::shared_ptr<Clipping> clip = clip_;
+    std::shared_ptr<ClippingRender> clip = clip_;
 
     if (!clip) {
-        clip.reset(new Clipping(edt_path_->value(), true));
+        clip.reset(new ClippingRender(edt_path_->value(), true));
         auto key1 = clip->at(start_frame);
         auto key2 = clip->at(end_frame - 1);
 

--- a/src/wnd_tools/encoder_window.h
+++ b/src/wnd_tools/encoder_window.h
@@ -32,11 +32,11 @@ typedef std::map<std::string,std::string> string_map_t;
 class EncoderWindow {
  public:
     explicit EncoderWindow(History* history);
-    EncoderWindow(History *history, std::shared_ptr<Clipping> clip);
+    EncoderWindow(History *history, std::shared_ptr<ClippingRender> clip);
     EncoderWindow(History *history, const std::string & path);
     virtual ~EncoderWindow();
     static void execute(History* history, Fl_Window *parent);
-    static void execute(History* history, Fl_Window *parent, std::shared_ptr<Clipping> clip);
+    static void execute(History* history, Fl_Window *parent, std::shared_ptr<ClippingRender> clip);
     static void execute(History* history, Fl_Window *parent, const std::string& path);
     static void restore_session(History* history, Fl_Window *parent);
 
@@ -44,7 +44,7 @@ class EncoderWindow {
     string_map_t serialize();
     bool deserialize(const string_map_t & data);
 
-    void init(History* history, std::shared_ptr<Clipping> clip);
+    void init(History* history, std::shared_ptr<ClippingRender> clip);
     void show_modal(Fl_Window *parent);
     void fill_animation_info(int video_frame_count);
     void copy_original_fps();
@@ -71,7 +71,7 @@ class EncoderWindow {
     void sugest_output_file();
     const char *sugest_extension();
  private:
-    std::shared_ptr<Clipping> clip_;
+    std::shared_ptr<ClippingRender> clip_;
     int frame_w_;
     int frame_h_;
     std::string path_;


### PR DESCRIPTION
Require the width and height of output clip to be multple of 2.
Use a copy of the working clip in conversion process.
Fix JsonFile file removal on delete.