### PR TITLE
Include metadata to generated mp4 files

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Generate and build the project
 ```bash
 cmake .
 cmake --build .
-# the test will run after the command above
+the test will run after the command above
 ```
 
 Generate and build clearing first
@@ -103,7 +103,7 @@ Windows building
 ```
 # It's necessary mingw
 # The project was successfully compiled with: gcc.exe (i686-posix-dwarf-rev2, Built by MinGW-W64 project) 6.3.0
-cmake -G 'MinGW Makefiles' .
+cmake -G "MinGW Makefiles" .
 mingw32-make
 ```
 

--- a/src/clippings/clipping_conversion.cpp
+++ b/src/clippings/clipping_conversion.cpp
@@ -15,7 +15,10 @@ namespace vcutter {
 ClippingConversion::ClippingConversion(
     std::shared_ptr<ProgressHandler> prog_handler,
     std::shared_ptr<ClippingRender> clipping,
-    uint32_t max_memory
+    uint32_t max_memory,
+    const char *title,
+    const char *author,
+    const char *tags
 ) {
     max_memory_ = max_memory;
     clipping_ = clipping;
@@ -25,6 +28,9 @@ ClippingConversion::ClippingConversion(
     last_encoded_buffer_.store(NULL);
     current_alpha_ = 1.0;
     alpha_increment_ = 0;
+    author_ = author ? author : "";
+    title_ = title ? title : "";
+    tags_ = tags ? tags : "";
 }
 
 
@@ -40,7 +46,8 @@ bool ClippingConversion::prepare_conversion(
     transitions_.clear();
     last_encoded_buffer_.store(NULL);
 
-    encoder_ = vs::encoder(codec, path, clipping_->w(), clipping_->h(), 1000, fps * 1000, bitrate);
+    encoder_ = vs::encoder(codec, path, clipping_->w(), clipping_->h(), 1000, fps * 1000, bitrate,
+                           title_.c_str(), author_.c_str(), tags_.c_str());
 
     if (encoder_->error()) {
         error_ = encoder_->error();

--- a/src/clippings/clipping_conversion.h
+++ b/src/clippings/clipping_conversion.h
@@ -33,8 +33,8 @@ class ClippingConversion {
    ClippingConversion& operator=(const ClippingConversion&) = delete;
  public:
     ClippingConversion(
-       std::shared_ptr<ProgressHandler> prog_handler, 
-       std::shared_ptr<ClippingRender> clipping, 
+       std::shared_ptr<ProgressHandler> prog_handler,
+       std::shared_ptr<ClippingRender> clipping,
       uint32_t max_memory=419430400,
       const char *title=NULL,
       const char *author=NULL,

--- a/src/clippings/clipping_conversion.h
+++ b/src/clippings/clipping_conversion.h
@@ -9,6 +9,7 @@
 #include <memory>
 #include <list>
 #include <atomic>
+#include <string>
 #include "src/clippings/clipping_iterator.h"
 #include "src/clippings/clipping.h"
 #include "src/common/buffers.h"
@@ -31,7 +32,13 @@ class ClippingConversion {
    ClippingConversion(const ClippingConversion&) = delete;
    ClippingConversion& operator=(const ClippingConversion&) = delete;
  public:
-    ClippingConversion(std::shared_ptr<ProgressHandler> prog_handler, std::shared_ptr<ClippingRender> clipping, uint32_t max_memory=419430400);
+    ClippingConversion(
+       std::shared_ptr<ProgressHandler> prog_handler, 
+       std::shared_ptr<ClippingRender> clipping, 
+      uint32_t max_memory=419430400,
+      const char *title=NULL,
+      const char *author=NULL,
+      const char *tags=NULL);
 
     bool convert(
         const char *codec,
@@ -70,6 +77,9 @@ class ClippingConversion {
     std::unique_ptr<ClippingIterator> clip_iter_;
     std::list<std::shared_ptr<CharBuffer> > transitions_;
     std::string error_;
+    std::string author_;
+    std::string title_;
+    std::string tags_;
     float current_alpha_;
     float alpha_increment_;
     uint32_t max_memory_;

--- a/src/vstream/encoder.cpp
+++ b/src/vstream/encoder.cpp
@@ -225,7 +225,7 @@ bool EncoderImp::allocate_format() {
         av_dict_set(&format_ctx_->metadata , "title", title_.c_str(), 0);
         av_dict_set(&format_ctx_->metadata , "artist", author_.c_str(), 0);
         av_dict_set(&format_ctx_->metadata , "comment", tags_.c_str(), 0);
-        av_dict_set(&format_ctx_->metadata , "description", "encoding using https://github.com/rodjjo/smart-vcutter", 0);
+        av_dict_set(&format_ctx_->metadata , "description", "encoded using https://github.com/rodjjo/smart-vcutter", 0);
     }
 
     return true;

--- a/src/vstream/encoder.cpp
+++ b/src/vstream/encoder.cpp
@@ -224,8 +224,8 @@ bool EncoderImp::allocate_format() {
     if (strcmp(format_name, "mp4") == 0) {
         av_dict_set(&format_ctx_->metadata , "title", title_.c_str(), 0);
         av_dict_set(&format_ctx_->metadata , "artist", author_.c_str(), 0);
-        av_dict_set(&format_ctx_->metadata , "description", tags_.c_str(), 0);
-        av_dict_set(&format_ctx_->metadata , "comment", "encoding using https://github.com/rodjjo/smart-vcutter", 0);
+        av_dict_set(&format_ctx_->metadata , "comment", tags_.c_str(), 0);
+        av_dict_set(&format_ctx_->metadata , "description", "encoding using https://github.com/rodjjo/smart-vcutter", 0);
     }
 
     return true;

--- a/src/vstream/encoder.cpp
+++ b/src/vstream/encoder.cpp
@@ -53,6 +53,9 @@ int Encoder::default_bitrate(const char *format_name, unsigned int w, unsigned i
 EncoderImp::EncoderImp(
     const char *codec_name,
     const char *path,
+    const char *title,
+    const char *author,
+    const char *tags,
     unsigned int frame_width,
     unsigned int frame_height,
     int fps_numerator,
@@ -66,6 +69,9 @@ EncoderImp::EncoderImp(
     codec_ = NULL;
     codec_name_ = codec_name;
     path_ = path;
+    tags_ = tags;
+    title_ = title;
+    author_ = author;
     frame_pts_ = 0;
     got_packet_ptr_ = 0;
     frame_width_ = frame_width;
@@ -214,6 +220,14 @@ bool EncoderImp::allocate_format() {
     }
 
     format_ctx_ = vs::allocate_format_context(context);
+
+    if (strcmp(format_name, "mp4") == 0) {
+        av_dict_set(&format_ctx_->metadata , "title", title_.c_str(), 0);
+        av_dict_set(&format_ctx_->metadata , "artist", author_.c_str(), 0);
+        av_dict_set(&format_ctx_->metadata , "description", tags_.c_str(), 0);
+        av_dict_set(&format_ctx_->metadata , "comment", "encoding using https://github.com/rodjjo/smart-vcutter", 0);
+    }
+
     return true;
 }
 

--- a/src/vstream/encoder.h
+++ b/src/vstream/encoder.h
@@ -18,6 +18,9 @@ class EncoderImp: public Encoder {
     EncoderImp(
         const char *codec_name,
         const char *path,
+        const char *title,
+        const char *author,
+        const char *tags,
         unsigned int frame_width,
         unsigned int frame_height,
         int fps_numerator,
@@ -54,6 +57,11 @@ class EncoderImp: public Encoder {
 
     std::string codec_name_;
     std::string path_;
+
+    std::string title_;
+    std::string author_;
+    std::string tags_;
+
     unsigned int frame_width_;
     unsigned int frame_height_;
     int max_bidirectional_frames_;

--- a/src/vstream/video_stream.cpp
+++ b/src/vstream/video_stream.cpp
@@ -25,11 +25,17 @@ std::shared_ptr<Encoder> encoder(
     unsigned int frame_height,
     int fps_numerator,
     int fps_denominator,
-    int bit_rate
+    int bit_rate,
+    const char *title,
+    const char *author,
+    const char *tags
 ) {
     return std::shared_ptr<vs::Encoder>(new vs::EncoderImp(
         codec_name,
         path,
+        title ? title : "",
+        author ? author : "",
+        tags ? tags : "",
         frame_width,
         frame_height,
         fps_numerator,

--- a/src/vstream/video_stream.h
+++ b/src/vstream/video_stream.h
@@ -71,7 +71,10 @@ std::shared_ptr<Encoder> encoder(
     unsigned int frame_height,
     int fps_numerator,
     int fps_denominator,
-    int bit_rate
+    int bit_rate,
+    const char *title=NULL,
+    const char *author=NULL,
+    const char *tags=NULL
 );
 
 

--- a/src/wnd_tools/encoder_window.cpp
+++ b/src/wnd_tools/encoder_window.cpp
@@ -21,7 +21,7 @@ const char *kCLIPPING_DIR_KEY = "ews-clipping-dir";
 const char *kCONVERSION_DIR_KEY = "ews-conversion-dir";
 
 const int kWINDOW_WIDTH = 700;
-const int kWINDOW_HEIGHT = 300;
+const int kWINDOW_HEIGHT = 410;
 
 const char *kEDT_PATH_FIELD = "source_path";
 const char *kEDT_OUTPUT_FIELD = "target_path";
@@ -112,6 +112,13 @@ void EncoderWindow::init(History* history, std::shared_ptr<ClippingRender> clip)
     edt_fps_->align(FL_ALIGN_TOP_LEFT);
 
     btn_fps_ = new Fl_Button(edt_fps_->x() + edt_fps_->w() + 1,  edt_fps_->y(), 60, 25, "change");
+
+    edt_title_ = new Fl_Input(5, btn_fps_->y() + 25 + btn_fps_->h(), window_->w() - 37, 25, "Title:");
+    edt_title_->align(FL_ALIGN_TOP_LEFT);
+    edt_author_ = new Fl_Input(5, edt_title_->y() + 25 + edt_title_->h(), window_->w() - 37, 25, "Author:");
+    edt_author_->align(FL_ALIGN_TOP_LEFT);
+    edt_tags_ = new Fl_Input(5, edt_author_->y() + 25 + edt_author_->h(), window_->w() - 37, 25, "Description:");
+    edt_tags_->align(FL_ALIGN_TOP_LEFT);
 
     components_group_->end();
 
@@ -512,7 +519,7 @@ void EncoderWindow::action_convert() {
         clip->add(key2);
     }
 
-    ClippingConversion conv(prog, clip);
+    ClippingConversion conv(prog, clip, 419430400, edt_title_->value(), edt_author_->value(), edt_tags_->value());
     conv.convert(
         format,
         edt_output_->value(),

--- a/src/wnd_tools/encoder_window.h
+++ b/src/wnd_tools/encoder_window.h
@@ -99,6 +99,9 @@ class EncoderWindow {
     Fl_Spinner *spn_transitions_;
     Fl_Input *edt_start_;
     Fl_Input *edt_end_;
+    Fl_Input *edt_title_;
+    Fl_Input *edt_author_;
+    Fl_Input *edt_tags_;
     Fl_Button *btn_fps_;
     Fl_Button *btn_path_;
     Fl_Button *btn_output_;


### PR DESCRIPTION
Include title, author and comment.

Description is also included, but is not editable and contains the text:
`encoded using https://github.com/rodjjo/smart-vcutter`